### PR TITLE
Add softmax transform with augmentation

### DIFF
--- a/simplex-softmax-augmented/simplex-softmax-augmented.stan
+++ b/simplex-softmax-augmented/simplex-softmax-augmented.stan
@@ -1,0 +1,13 @@
+data {
+ int<lower=0> N;
+}
+parameters {
+ vector[N] z;
+}
+transformed parameters {
+ real<lower=0> logr = log_sum_exp(z);
+ simplex[N] x = exp(z - logr);
+}
+model {
+ target += sum(z) - exp(2 * logr) / 2;
+}


### PR DESCRIPTION
@mjhajharia this is the simplex transformation I referenced in my e-mail.

Instead of performing softmax on a vector $\begin{pmatrix}z^\top & 0 \end{pmatrix}^\top \in \mathbb{R}^n$ like the other example in this repo, it performs softmax on $z \in \mathbb{R}^n$. Hence the latent space has an extra degree of freedom, and this is similar to Stan's unit vector approach.

I arrived at this transformation by starting with Example 2.4 of https://doi.org/10.1111/sjos.12036. Namely, let $x \in \Delta^{n-1} \subset \mathbb{R}^n$ be a point on the $n-1$-simplex. Since the simplex has the following constraints:
$$x_i > 0, \quad \sum_{x=1}^n x_i = 1,$$
we could let $w \in \mathbb{S}^{n-1} \subset \mathbb{R}^n$ be a unit vector. Then, if $x_i = w_i^2$, we arrive at the point on a simplex. If we likewise sample $w$ as an unconstrained vector in $\mathbb{R}^n$ as Stan does, we end up with a relatively simple transformation. However, we end up with $2^n$ points in $\mathbb{S}^{n-1}$ mapping to a single point in $\Delta^{n-1}$, so in the latent space, we end up with $2^n$ times however many modes are already in the posterior on the simplex.

The $2^n$ combinations come from each $x_i$ having two values of $w_i$ that can map to it: $w_i > 0$ or $w_i < 0$. The sign of $x_i$ is the same as the latent space sign $z_i$, so the trick to remove the nonidentifiability is to precompose the transformation from latent space to unit vectors (normalization) with an element-wise exponential. The result is the softmax!

The extra degree of freedom is
$$r = \sum_{i=1}^n e^{z_i},$$
i.e. the denominator in softmax. We need to choose a prior for this dof, or we end up with an improper posterior. If we choose $r \sim \chi_n$ (same as the implicit prior Stan uses for the discarded magnitude in the latent space of unit vectors), then we arrive at the implementation in this model, though other choices are possible.

For low $n$, this is a truly awful parameterization (terrible r-hats). But I've checked $n=10$, and it's almost as good as Stan's default parameterization for sampling a uniform distribution (in terms of high ESS and ESS/s).