### PR TITLE
Feature/corr cholesky [WIP]

### DIFF
--- a/transforms/cholesky/stan_transform.stan
+++ b/transforms/cholesky/stan_transform.stan
@@ -1,0 +1,32 @@
+data {
+  int<lower=0> K;
+}
+parameters {
+  vector[(K*(K-1)) %/% 2] y;
+}
+transformed parameters {
+  matrix[K, K] L = diag_matrix(rep_vector(1, K));
+  vector<lower=-1, upper=1>[(K*(K-1)) %/% 2] z = tanh(y);
+  real log_det_jacobian = 0;
+  {
+    int counter = 1;
+    real sum_sqs;
+
+    for (i in 2:K) {
+      L[i, 1] = z[counter];
+      counter += 1;
+      sum_sqs = square(L[i, 1]);
+      for (j in 2:(i-1)) {
+        log_det_jacobian += 0.5 * log1m(sum_sqs);
+        L[i, j] = z[counter] * sqrt(1 - sum_sqs);
+        counter += 1;
+        sum_sqs = sum_sqs + square(L[i, j]);
+      }
+      L[i, i] = sqrt(1 - sum_sqs);
+    }
+  }
+}
+model {
+  target += log_det_jacobian;
+  // target += target_density(L);
+}

--- a/transforms/cholesky/stan_transform.stan
+++ b/transforms/cholesky/stan_transform.stan
@@ -1,22 +1,25 @@
+#include transform_functions.stan
 data {
   int<lower=0> K;
 }
 parameters {
-  vector[(K*(K-1)) %/% 2] y;
+  // y is a vector K-choose-2 unconstrained parameters
+  vector[choose_2(K)] y;
 }
 transformed parameters {
-  matrix[K, K] L = diag_matrix(rep_vector(1, K));
-  vector<lower=-1, upper=1>[(K*(K-1)) %/% 2] z = tanh(y);
+  // L is a Cholesky factor of a K x K correlation matrix
+  cholesky_factor_corr[K] L = diag_matrix(rep_vector(1, K));
   real log_det_jacobian = 0;
   {
     int counter = 1;
     real sum_sqs;
-
-    for (i in 2:K) {
+    vector[choose_2(K)] z = tanh(y);
+    
+    for (i in 2 : K) {
       L[i, 1] = z[counter];
       counter += 1;
       sum_sqs = square(L[i, 1]);
-      for (j in 2:(i-1)) {
+      for (j in 2 : (i - 1)) {
         log_det_jacobian += 0.5 * log1m(sum_sqs);
         L[i, j] = z[counter] * sqrt(1 - sum_sqs);
         counter += 1;
@@ -28,5 +31,5 @@ transformed parameters {
 }
 model {
   target += log_det_jacobian;
-  target += lkj_corr_cholesky_lpdf(L | 2.);
+  target += lkj_corr_cholesky_lpdf(L | 2);
 }

--- a/transforms/cholesky/tfp_transform.stan
+++ b/transforms/cholesky/tfp_transform.stan
@@ -1,28 +1,27 @@
 data {
   int<lower=0> K;
 }
+transformed data {
+   
+}
 parameters {
   vector[(K*(K-1)) %/% 2] y;
 }
 transformed parameters {
   matrix[K, K] L = diag_matrix(rep_vector(1, K));
-  vector<lower=-1, upper=1>[(K*(K-1)) %/% 2] z = tanh(y);
-  real log_det_jacobian = 0;
+  real log_det_jacobian;
   {
     int counter = 1;
-    real sum_sqs;
 
     for (i in 2:K) {
-      L[i, 1] = z[counter];
+      L[i, 1] = y[counter];
       counter += 1;
-      sum_sqs = square(L[i, 1]);
       for (j in 2:(i-1)) {
-        log_det_jacobian += 0.5 * log1m(sum_sqs);
-        L[i, j] = z[counter] * sqrt(1 - sum_sqs);
+        L[i, j] = y[counter];
         counter += 1;
-        sum_sqs = sum_sqs + square(L[i, j]);
       }
-      L[i, i] = sqrt(1 - sum_sqs);
+      L[i , :i] = L[i , :i] / sqrt(sum(square(L[i , :i ])));
+      log_det_jacobian += (K - i + 1) * log(L[i,i]);
     }
   }
 }

--- a/transforms/cholesky/tfp_transform.stan
+++ b/transforms/cholesky/tfp_transform.stan
@@ -1,31 +1,31 @@
+#include transform_functions.stan
 data {
   int<lower=0> K;
 }
-transformed data {
-   
-}
 parameters {
-  vector[(K*(K-1)) %/% 2] y;
+  // y is a vector K-choose-2 unconstrained parameters
+  vector[choose_2(K)] y;
 }
 transformed parameters {
-  matrix[K, K] L = diag_matrix(rep_vector(1, K));
+  // L is a Cholesky factor of a K x K correlation matrix
+  cholesky_factor_corr[K] L = diag_matrix(rep_vector(1, K));
   real log_det_jacobian;
   {
     int counter = 1;
-
-    for (i in 2:K) {
+    
+    for (i in 2 : K) {
       L[i, 1] = y[counter];
       counter += 1;
-      for (j in 2:(i-1)) {
+      for (j in 2 : (i - 1)) {
         L[i, j] = y[counter];
         counter += 1;
       }
-      L[i , :i] = L[i , :i] / sqrt(sum(square(L[i , :i ])));
-      log_det_jacobian += (K - i + 1) * log(L[i,i]);
+      L[i,  : i] = L[i,  : i] / sqrt(sum(square(L[i,  : i])));
+      log_det_jacobian += (K - i + 1) * log(L[i, i]);
     }
   }
 }
 model {
   target += log_det_jacobian;
-  target += lkj_corr_cholesky_lpdf(L | 2.);
+  target += lkj_corr_cholesky_lpdf(L | 2);
 }

--- a/transforms/cholesky/transform_functions.stan
+++ b/transforms/cholesky/transform_functions.stan
@@ -1,0 +1,5 @@
+functions {
+  int choose_2(int K) {
+    return (K * (K - 1)) %/% 2;
+  }
+}


### PR DESCRIPTION
This PR implements two different ways to transform a vector of `K(K-1)/2` real numbers to a Cholesky factor of a `K x K` correlation matrix, addressing #24:
1. Stan's way, based on  https://github.com/stan-dev/math/blob/92075708b1d1796eb82e3b284cd11e544433518e/stan/math/rev/fun/cholesky_corr_constrain.hpp#L38-L52

2. TFP's way, based on https://github.com/tensorflow/probability/blob/v0.17.0/tensorflow_probability/python/bijectors/correlation_cholesky.py

I just want to make sure this is a sensible first step in the proposed workflow; I'll then address the other points raised in #24.

One thing I'm not sure about in the Stan implementation: as far as I understand, in this [line](https://github.com/stan-dev/math/blob/92075708b1d1796eb82e3b284cd11e544433518e/stan/math/rev/fun/cholesky_corr_constrain.hpp#L105) we are accounting for the jacobian correction of the `tanh` transform, whereas in this [line](https://github.com/stan-dev/math/blob/92075708b1d1796eb82e3b284cd11e544433518e/stan/math/rev/fun/cholesky_corr_constrain.hpp#L38) we do not; why is that? And, presumably, here we do want to account for that, right? (currently we do not, I need to change that).