### PR TITLE
black format all python files

### DIFF
--- a/script_simplex_stan.py
+++ b/script_simplex_stan.py
@@ -1,15 +1,25 @@
 import os
-os.chdir('transforms')
+
+os.chdir("transforms")
 
 import sys
-sys.path.insert(1, 'utils')
+
+sys.path.insert(1, "utils")
 
 from sample import sample
 
-parameters = [{'alpha': [1]*10, 'N': 10}]
-sample(transform_category='simplex', transform='stan', 
-    evaluating_model='dirichlet_symmetric', parameters=parameters, output_file='/mnt/ceph/users/mjhajaria/sampling_results/stan_1.json', 
-    auto_eval_all_params=False, n_iter = 1000, n_chains = 4, n_repeat = 1, 
-                       show_progress = True, resample=True, return_idata=False)
-
-
+parameters = [{"alpha": [1] * 10, "N": 10}]
+sample(
+    transform_category="simplex",
+    transform="stan",
+    evaluating_model="dirichlet_symmetric",
+    parameters=parameters,
+    output_file="/mnt/ceph/users/mjhajaria/sampling_results/stan_1.json",
+    auto_eval_all_params=False,
+    n_iter=1000,
+    n_chains=4,
+    n_repeat=1,
+    show_progress=True,
+    resample=True,
+    return_idata=False,
+)

--- a/utils/dirichlet_symmetric.py
+++ b/utils/dirichlet_symmetric.py
@@ -4,44 +4,67 @@ import matplotlib.pyplot as plt
 from rmse import rmse_leapfrog
 from sample import sample
 
-def get_dirichlet_symmetric_rmse(transforms, transform_category, parameters, fig_name, n_repeat=1, n_iter=1000, 
-                                n_chains=4, show_progress=True, resample=False):
-    
-    plt.rcParams["figure.figsize"] = [20,10]
-    plt.rcParams['figure.dpi'] = 300
+
+def get_dirichlet_symmetric_rmse(
+    transforms,
+    transform_category,
+    parameters,
+    fig_name,
+    n_repeat=1,
+    n_iter=1000,
+    n_chains=4,
+    show_progress=True,
+    resample=False,
+):
+
+    plt.rcParams["figure.figsize"] = [20, 10]
+    plt.rcParams["figure.dpi"] = 300
     fig, axes = plt.subplots(len(parameters))
-    fig.supxlabel('Cumulative Leapfrog Steps')
-    fig.supylabel('Root Mean Squared Error')
+    fig.supxlabel("Cumulative Leapfrog Steps")
+    fig.supylabel("Root Mean Squared Error")
 
-    for ax, params in zip(axes.flatten() if len(parameters)>1 else [axes],  parameters):
-        for transform in transforms:            
-            idata = sample(transform_category=transform_category, transform=transform, 
-                evaluating_model='dirichlet_symmetric', parameters=[params], output_file=None, 
-                auto_eval_all_params=False, n_iter = n_iter, n_chains = n_chains, n_repeat = n_repeat, 
-                                        show_progress = show_progress, resample=resample)
-            alpha = params['alpha']
-            N = params['N']
-            true_x = [a/sum(alpha) for a in alpha]
-            x, y = rmse_leapfrog(idata=idata, true_var=true_x, var_name='x', var_dim=0)
-            ax.plot(x,y, label = str(transform))
+    for ax, params in zip(
+        axes.flatten() if len(parameters) > 1 else [axes], parameters
+    ):
+        for transform in transforms:
+            idata = sample(
+                transform_category=transform_category,
+                transform=transform,
+                evaluating_model="dirichlet_symmetric",
+                parameters=[params],
+                output_file=None,
+                auto_eval_all_params=False,
+                n_iter=n_iter,
+                n_chains=n_chains,
+                n_repeat=n_repeat,
+                show_progress=show_progress,
+                resample=resample,
+            )
+            alpha = params["alpha"]
+            N = params["N"]
+            true_x = [a / sum(alpha) for a in alpha]
+            x, y = rmse_leapfrog(idata=idata, true_var=true_x, var_name="x", var_dim=0)
+            ax.plot(x, y, label=str(transform))
 
-        ax.set_title(f'alpha={alpha[0]}, N = {N}')
-    fig.legend(labels=transforms,bbox_to_anchor = (0.6, -0.05));
-    fig.savefig(f'figures/{fig_name}', dpi=300)
+        ax.set_title(f"alpha={alpha[0]}, N = {N}")
+    fig.legend(labels=transforms, bbox_to_anchor=(0.6, -0.05))
+    fig.savefig(f"figures/{fig_name}", dpi=300)
+
 
 def create_param_map():
     alphas = [0.1, 1, 10]
     Ns = [10, 100, 1000]
-    keys=[1,2,3,4,5,6,7,8,9]
-    params=[]
+    keys = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    params = []
     for alpha in alphas:
         for N in Ns:
-            parameters.append({'alpha': [alpha]*N, 'N': N})
+            parameters.append({"alpha": [alpha] * N, "N": N})
 
-    param_map=dict(zip(keys, params))
+    param_map = dict(zip(keys, params))
     param_map.update(dict(zip(params, keys)))
 
-    pickle.dump(param_map, open('param_map_dirichlet_symmmetric.pkl', 'wb'))
+    pickle.dump(param_map, open("param_map_dirichlet_symmmetric.pkl", "wb"))
+
 
 def get_dirichlet_symmetric_params():
-    return pickle.load(open('param_map_dirichlet_symmmetric.pkl', 'rb'))
+    return pickle.load(open("param_map_dirichlet_symmmetric.pkl", "rb"))

--- a/utils/ess.py
+++ b/utils/ess.py
@@ -5,21 +5,33 @@ from cmdstanpy import CmdStanModel
 from tqdm import tqdm
 import arviz as az
 
-def get_ess_leapfrog_ratio(transform_category, transform, evaluating_model, params, var_name, var_dim, repeat=100, return_ess=False):
-    model = CmdStanModel(stan_file = f'stan_models/{transform}_{evaluating_model}.stan', cpp_options = {'STAN_THREADS':'true'})
-    x=[]
+
+def get_ess_leapfrog_ratio(
+    transform_category,
+    transform,
+    evaluating_model,
+    params,
+    var_name,
+    var_dim,
+    repeat=100,
+    return_ess=False,
+):
+    model = CmdStanModel(
+        stan_file=f"stan_models/{transform}_{evaluating_model}.stan",
+        cpp_options={"STAN_THREADS": "true"},
+    )
+    x = []
     for i in tqdm(range(repeat)):
-        idata = az.from_cmdstanpy(model.sample(data=params,show_progress=False ))
-        data=idata.sel(var_names=[str(var_name)], x_dim_0=var_dim)
-        ess = az.ess(data, var_names=[str(var_name)], method="bulk")[str(var_name)].values
-        leapfrog = idata.sample_stats['n_steps'].sum().values
-        x.append(ess/leapfrog)
-    if return_ess==True:
+        idata = az.from_cmdstanpy(model.sample(data=params, show_progress=False))
+        data = idata.sel(var_names=[str(var_name)], x_dim_0=var_dim)
+        ess = az.ess(data, var_names=[str(var_name)], method="bulk")[
+            str(var_name)
+        ].values
+        leapfrog = idata.sample_stats["n_steps"].sum().values
+        x.append(ess / leapfrog)
+    if return_ess == True:
         return x
     else:
         kde = gaussian_kde(x)
-        dist_space = np.linspace( min(x), max(x), 1000)
+        dist_space = np.linspace(min(x), max(x), 1000)
         return dist_space, kde(dist_space)
-
-
-

--- a/utils/rhat.py
+++ b/utils/rhat.py
@@ -3,61 +3,75 @@ import arviz as az
 import numpy as np
 from cmdstanpy import CmdStanModel
 import logging
-logger = logging.getLogger('cmdstanpy')
+
+logger = logging.getLogger("cmdstanpy")
 logger.addHandler(logging.NullHandler())
 
+
 def calc_rhat_mixed_chains(path_1, path_2, variable, data, force_compile=False):
-    
+
     """
     This function evaluates rhat for 4 chains from 2 different models, as in 2 chains from each.
-    
+
     Parameters
     ----------
-    
+
     path_1: str
         path for the first model
-        
+
     path_2: str
         path for the second model
-    
+
     variable: str
         Variable to evaluate rhat for
-    
+
     data: dict
         Dictionary of data
-    
+
     force_compile: Bool
         Whether to recompile or not
 
     """
-    #Build stan model
+    # Build stan model
     file_1 = os.path.join(path_1)
     file_2 = os.path.join(path_2)
-    model_1 = CmdStanModel(stan_file=file_1, cpp_options={'STAN_THREADS':'true'})
-    model_2 = CmdStanModel(stan_file=file_2, cpp_options={'STAN_THREADS':'true'})
-    
-    #Recompile
+    model_1 = CmdStanModel(stan_file=file_1, cpp_options={"STAN_THREADS": "true"})
+    model_2 = CmdStanModel(stan_file=file_2, cpp_options={"STAN_THREADS": "true"})
+
+    # Recompile
     if force_compile is True:
         model_1.compile(force=True)
         model_2.compile(force=True)
-        
-    rhat_array=[]
+
+    rhat_array = []
     for i in range(10):
-        #Fit stan model
-        fit_1 = model_1.sample(data=data, show_progress=False, iter_sampling=1000, chains=4)
-        fit_2 = model_2.sample(data=data, show_progress=False, iter_sampling=1000, chains=4)
-        
-        #Convert to idata for arviz
+        # Fit stan model
+        fit_1 = model_1.sample(
+            data=data, show_progress=False, iter_sampling=1000, chains=4
+        )
+        fit_2 = model_2.sample(
+            data=data, show_progress=False, iter_sampling=1000, chains=4
+        )
+
+        # Convert to idata for arviz
         idata_1 = az.from_cmdstanpy(fit_1)
         idata_2 = az.from_cmdstanpy(fit_2)
-        
-        #Stack the samples according to chains
+
+        # Stack the samples according to chains
         stacked_1 = az.extract_dataset(idata_1)
         stacked_2 = az.extract_dataset(idata_2)
-        
-        #Concatenate chains and evaluate rhat
-        chains = np.concatenate((stacked_1.sel(chain=1)[variable], stacked_1.sel(chain=2)[variable], stacked_2.sel(chain=1)[variable], stacked_2.sel(chain=2)[variable]), axis=1)
-        rhat = az.rhat(chains, var_names=variable,method="rank")
+
+        # Concatenate chains and evaluate rhat
+        chains = np.concatenate(
+            (
+                stacked_1.sel(chain=1)[variable],
+                stacked_1.sel(chain=2)[variable],
+                stacked_2.sel(chain=1)[variable],
+                stacked_2.sel(chain=2)[variable],
+            ),
+            axis=1,
+        )
+        rhat = az.rhat(chains, var_names=variable, method="rank")
         rhat_array.append(rhat)
-    
+
     return np.asarray(rhat_array).mean()

--- a/utils/rmse.py
+++ b/utils/rmse.py
@@ -2,17 +2,21 @@ import numpy as np
 import matplotlib.pyplot as plt
 from sample import sample
 
+
 def rmse(y_true, y_pred):
-    return np.sqrt(np.mean((y_true - y_pred)**2))
+    return np.sqrt(np.mean((y_true - y_pred) ** 2))
+
 
 def cumulative_mean(x):
     return np.divide(np.cumsum(x), np.arange(1, len(x) + 1))
 
+
 def rmse_leapfrog(idata, true_var, var_name, var_dim):
     cumulative_leapfrog_steps = np.cumsum(np.mean(idata.sample_stats.n_steps, axis=0))
-    pred_var = cumulative_mean(np.mean(idata.posterior[str(var_name)].sel(x_dim_0=var_dim), axis=0))
-    rmse_array=[]
-    for i in range(1, len(pred_var)+1):
+    pred_var = cumulative_mean(
+        np.mean(idata.posterior[str(var_name)].sel(x_dim_0=var_dim), axis=0)
+    )
+    rmse_array = []
+    for i in range(1, len(pred_var) + 1):
         rmse_array.append(rmse(true_var[var_dim], pred_var[:i]))
     return cumulative_leapfrog_steps, rmse_array
-

--- a/utils/sample.py
+++ b/utils/sample.py
@@ -9,13 +9,27 @@ import argparse
 import arviz as az
 from pathlib import Path
 from tqdm import tqdm
+
 # import logging
 # logger = logging.getLogger('cmdstanpy')
 # logger.addHandler(logging.NullHandler())
 
-def sample(transform_category, transform, evaluating_model, parameters, output_file=None, 
-                auto_eval_all_params=False, n_iter = 1000, n_chains = 4, n_repeat = 1, show_progress = True, resample=False, return_idata=True):
-    '''
+
+def sample(
+    transform_category,
+    transform,
+    evaluating_model,
+    parameters,
+    output_file=None,
+    auto_eval_all_params=False,
+    n_iter=1000,
+    n_chains=4,
+    n_repeat=1,
+    show_progress=True,
+    resample=False,
+    return_idata=True,
+):
+    """
     Sample from the given dictionary containing the models, transform_categories, and parameters.
     It saves the results in a json file which is named with n_repeat, n_chains and n_iter.
 
@@ -23,13 +37,13 @@ def sample(transform_category, transform, evaluating_model, parameters, output_f
     ----------
     transform_category: str
         The transform category to use.
-    
+
     transform: str
         The transform name to use.
-    
+
     evaluating_model: str
         The model to use.
-    
+
     parameters: list of dict
         List of Dictionaries containing the parameters to use.
         e.g. parameters = [{'alpha': [0.1]*10, 'N': 10}, {'alpha': [0.1]*20, 'N': 20}]
@@ -57,7 +71,7 @@ def sample(transform_category, transform, evaluating_model, parameters, output_f
 
     resample: bool (default = False)
         Whether to resample the data.
-    
+
     return_idata: bool (default = True)
         Whether to return the idata.
 
@@ -65,37 +79,55 @@ def sample(transform_category, transform, evaluating_model, parameters, output_f
     ----
     The directory structure for storing stan files is: stan_models/{transform}_{evaluating_model}.stan
     The directory structure for storing the results is: sampling_results/{transform_category}/{transform}/{evaluating_model}/{param_mapping}.json
-    '''
-    with open(f'target_densities/param_map_{evaluating_model}.json', 'rb') as f:
+    """
+    with open(f"target_densities/param_map_{evaluating_model}.json", "rb") as f:
         param_map = pickle.load(f)
 
-    if resample==False:
+    if resample == False:
         for params in parameters:
-            filename = f'sampling_results/{transform_category}/{transform}/{evaluating_model}/{param_map[tuple(list(params.values())[0])]}_{n_repeat}.json'
+            filename = f"sampling_results/{transform_category}/{transform}/{evaluating_model}/{param_map[tuple(list(params.values())[0])]}_{n_repeat}.json"
             return az.from_json(filename)
     else:
 
         if auto_eval_all_params:
-            with open(f'target_densities/{evaluating_model}_parameters.json', 'rb') as f:
+            with open(
+                f"target_densities/{evaluating_model}_parameters.json", "rb"
+            ) as f:
                 parameters = pickle.load(f)
-        
 
+        stan_filename = f"stan_models/{transform}_{evaluating_model}.json"
 
-        stan_filename=f'stan_models/{transform}_{evaluating_model}.json'
-        
-        if type(parameters)==dict:
+        if type(parameters) == dict:
             parameters = [parameters]
         for params in tqdm(parameters):
-            model = CmdStanModel(stan_file = stan_filename, cpp_options = {'STAN_THREADS':'true'})
-            idata = az.from_cmdstanpy(model.sample(data = params, show_progress = show_progress, iter_sampling = n_iter, chains = n_chains))
+            model = CmdStanModel(
+                stan_file=stan_filename, cpp_options={"STAN_THREADS": "true"}
+            )
+            idata = az.from_cmdstanpy(
+                model.sample(
+                    data=params,
+                    show_progress=show_progress,
+                    iter_sampling=n_iter,
+                    chains=n_chains,
+                )
+            )
 
-            for i in range(n_repeat-1):
-                fit = model.sample(data = params, show_progress = show_progress, iter_sampling = n_iter, chains = n_chains)
+            for i in range(n_repeat - 1):
+                fit = model.sample(
+                    data=params,
+                    show_progress=show_progress,
+                    iter_sampling=n_iter,
+                    chains=n_chains,
+                )
                 idata = az.concat(idata, az.from_cmdstanpy(fit), dim="chain")
 
-            filename = output_file if output_file else f'sampling_results/{transform_category}/{transform}/{evaluating_model}/{param_map[tuple(list(params.values())[0])]}_{n_repeat}.json'
+            filename = (
+                output_file
+                if output_file
+                else f"sampling_results/{transform_category}/{transform}/{evaluating_model}/{param_map[tuple(list(params.values())[0])]}_{n_repeat}.json"
+            )
             idata.to_json(filename)
-            if return_idata==True:
+            if return_idata == True:
                 return idata
 
         pass


### PR DESCRIPTION
This PR uses `black` to format all the Python files in the repo.

Definitely not critical, just thought it'd be nicer to have consistent formatting on the Python side, as well. Feel free to close if you don't like the style or think this is unnecessary.