### PR TITLE
Add normalized exponential transform

### DIFF
--- a/transforms/simplex/NormalizedExponential.stan
+++ b/transforms/simplex/NormalizedExponential.stan
@@ -23,8 +23,7 @@ transformed parameters {
       r += z[i];
       log_det_jacobian += std_normal_lpdf(y[i]);
     }
-    for (i in 1:N)
-      x[i] = z[i] / r;
+    x = z / r;
   }
 }
 model {

--- a/transforms/simplex/NormalizedExponential.stan
+++ b/transforms/simplex/NormalizedExponential.stan
@@ -1,0 +1,33 @@
+functions {
+    real exponential_log_qf(real logp){
+        return -log1m_exp(logp);
+    }
+}
+data {
+  int<lower=0> N;
+  vector<lower=0>[N] alpha;
+}
+parameters {
+  vector[N] y;
+}
+transformed parameters {
+  simplex[N] x;
+  real<lower=0> r = 0;
+  real log_det_jacobian = 0;
+  {
+    vector[N] z;
+    real log_u;
+    for (i in 1:N) {
+      log_u = std_normal_lcdf(y[i]);
+      z[i] = exponential_log_qf(log_u);
+      r += z[i];
+      log_det_jacobian += std_normal_lpdf(y[i]);
+    }
+    for (i in 1:N)
+      x[i] = z[i] / r;
+  }
+}
+model {
+  target += log_det_jacobian; 
+  target += target_density_lp(x, alpha);
+}


### PR DESCRIPTION
This PR adds the "Normalized Exponential" transform (name TBD). It's the special case of the "Normalized Gamma" (also TBD) proposed by @nsiccha on Slack for $\alpha=\mathbf{1}$. To support Normalized Gamma for arbitrary $\alpha$, Stan needs an implementation of the inverse incomplete gamma function.