### PR TITLE
Fix augmented-softmax

### DIFF
--- a/transforms/simplex/AugmentedSoftmax.stan
+++ b/transforms/simplex/AugmentedSoftmax.stan
@@ -6,7 +6,7 @@ parameters {
  vector[N] y;
 }
 transformed parameters {
- real<lower=0> logr = log_sum_exp(y);
+ real logr = log_sum_exp(y);
  simplex[N] x = exp(y - logr);
 }
 model {

--- a/transforms/simplex/AugmentedSoftmax.stan
+++ b/transforms/simplex/AugmentedSoftmax.stan
@@ -10,6 +10,7 @@ transformed parameters {
  simplex[N] x = exp(y - logr);
 }
 model {
- target += sum(y) - N * logr - (logr - log(N))^2 / 2;
+ target += sum(y) - N * logr;  // target += log(prod(x))
+ target += std_normal_lupdf(logr - log(N));
  target += target_density_lp(x, alpha);
 }

--- a/transforms/simplex/AugmentedSoftmax.stan
+++ b/transforms/simplex/AugmentedSoftmax.stan
@@ -10,6 +10,6 @@ transformed parameters {
  simplex[N] x = exp(y - logr);
 }
 model {
- target += sum(y) - exp((1/N) * logr)*N;
+ target += sum(y) - N * logr - (logr - log(N))^2 / 2;
  target += target_density_lp(x, alpha);
 }


### PR DESCRIPTION
This PR makes several needed fixes to augmented-softmax:
- The implementation incorrectly constrained `logr` to be positive.
- The Jacobian determinant in the paper was off by a factor of `r` and is now corrected
- The default prior is now better motivated. If `y` is IID std normal distributed, then `logr` is approximately normally distributed with a mean in the range `(log(N), log(N) + 1/2)` and standard deviation in the range `(0, 1)`. We choose the default prior of `logr ~ Normal(log(N), 1)` to shift the distribution of `y` to be closer to the origin when `x` is uniform on the simplex.

I expect these improvements will improve the performance of augmented-softmax in the comparisons.