### PR TITLE
Add transforms for log-simplex

### DIFF
--- a/target_densities/LogDirichlet.stan
+++ b/target_densities/LogDirichlet.stan
@@ -2,10 +2,7 @@ functions {
   real log_dirichlet_lpdf(vector log_theta, vector alpha) {
     int N = rows(log_theta);
     if (N != rows(alpha)) reject("Input must contain same number of elements as alpha");
-    real lp = 0;
-    for (i in 1:N)
-      lp += alpha[i] * log_theta[i];
-    lp -= log_theta[N];
+    real lp = dot_product(alpha, log_theta) - log_theta[N];
     lp += sum(lgamma(alpha)) - lgamma(sum(alpha));
     return lp;
   }

--- a/target_densities/LogDirichlet.stan
+++ b/target_densities/LogDirichlet.stan
@@ -1,0 +1,15 @@
+functions {
+  real log_dirichlet_lpdf(vector log_theta, vector alpha) {
+    int N = rows(log_theta);
+    if (N != rows(alpha)) reject("Input must contain same number of elements as alpha");
+    real lp = 0;
+    for (i in 1:N)
+      lp += alpha[i] * log_theta[i];
+    lp -= log_theta[N];
+    lp += sum(lgamma(alpha)) - lgamma(sum(alpha));
+    return lp;
+  }
+  real target_density_lp(vector log_x, vector alpha){
+    return log_dirichlet_lpdf(log_x | alpha);
+  }
+}

--- a/transforms/log_simplex/ALR.stan
+++ b/transforms/log_simplex/ALR.stan
@@ -19,6 +19,7 @@ parameters {
 }
 transformed parameters {
   vector<upper=0>[N] log_x = inv_alr_log_simplex_constrain_lp(y);
+  simplex[N] x = exp(log_x);
 }
 model {
   target += target_density_lp(log_x, alpha);

--- a/transforms/log_simplex/ALR.stan
+++ b/transforms/log_simplex/ALR.stan
@@ -1,0 +1,25 @@
+functions{
+  vector inv_alr_log_simplex_constrain_lp(vector y){
+    int N = rows(y) + 1;
+    vector[N] log_x;
+    real log_r = log1p_exp(log_sum_exp(y));
+    for (i in 1:(N - 1))
+      log_x[i] = y[i] - log_r;
+    log_x[N] = -log_r;
+    target += -log_r;
+    return log_x;
+  }
+}
+data {
+  int<lower=0> N;
+  vector<lower=0>[N] alpha;
+}
+parameters {
+  vector[N - 1] y;
+}
+transformed parameters {
+  vector<upper=0>[N] log_x = inv_alr_log_simplex_constrain_lp(y);
+}
+model {
+  target += target_density_lp(log_x, alpha);
+}

--- a/transforms/log_simplex/ALR.stan
+++ b/transforms/log_simplex/ALR.stan
@@ -1,10 +1,9 @@
-functions{
+functions {
   vector inv_alr_log_simplex_constrain_lp(vector y){
     int N = rows(y) + 1;
-    vector[N] log_x;
     real log_r = log1p_exp(log_sum_exp(y));
-    for (i in 1:(N - 1))
-      log_x[i] = y[i] - log_r;
+    vector[N] log_x;
+    log_x[1:N - 1] = y - log_r;
     log_x[N] = -log_r;
     target += -log_r;
     return log_x;

--- a/transforms/log_simplex/AugmentedILR.stan
+++ b/transforms/log_simplex/AugmentedILR.stan
@@ -1,11 +1,10 @@
 functions{
   vector inv_ilr_log_simplex_constrain_lp(vector y, matrix Vinv){
     int N = rows(y) + 1;
-    vector[N] log_x;
     vector[N - 1] s = Vinv * y;
     real log_r = log1p_exp(log_sum_exp(s));
-    for (n in 1:(N - 1))
-      log_x[n] = s[n] - log_r;
+    vector[N] log_x;
+    log_x[1:N - 1] = s - log_r;
     log_x[N] = -log_r;
     target += log(N) - log_r;
     return log_x;

--- a/transforms/log_simplex/AugmentedILR.stan
+++ b/transforms/log_simplex/AugmentedILR.stan
@@ -23,6 +23,7 @@ parameters {
 }
 transformed parameters {
   vector<upper=0>[N] log_x = inv_ilr_log_simplex_constrain_lp(y, Vinv);
+  simplex[N] x = exp(log_x);
 }
 model {
   target += target_density_lp(log_x, alpha);

--- a/transforms/log_simplex/AugmentedILR.stan
+++ b/transforms/log_simplex/AugmentedILR.stan
@@ -1,0 +1,29 @@
+functions{
+  vector inv_ilr_log_simplex_constrain_lp(vector y, matrix Vinv){
+    int N = rows(y) + 1;
+    vector[N] log_x;
+    vector[N - 1] s = Vinv * y;
+    real log_r = log1p_exp(log_sum_exp(s));
+    for (n in 1:(N - 1))
+      log_x[n] = s[n] - log_r;
+    log_x[N] = -log_r;
+    target += log(N) - log_r;
+    return log_x;
+  }
+}
+data {
+  int<lower=0> N;
+  vector<lower=0>[N] alpha;
+}
+transformed data {
+  matrix[N - 1, N - 1] Vinv = construct_vinv(N);
+}
+parameters {
+  vector[N - 1] y;
+}
+transformed parameters {
+  vector<upper=0>[N] log_x = inv_ilr_log_simplex_constrain_lp(y, Vinv);
+}
+model {
+  target += target_density_lp(log_x, alpha);
+}

--- a/transforms/log_simplex/AugmentedSoftmax.stan
+++ b/transforms/log_simplex/AugmentedSoftmax.stan
@@ -17,6 +17,7 @@ parameters {
 }
 transformed parameters {
   vector<upper=0>[N] log_x = augmented_softmax_log_simplex_constrain_lp(y);
+  simplex[N] x = exp(log_x);
 }
 model {
   target += target_density_lp(x, alpha);

--- a/transforms/log_simplex/AugmentedSoftmax.stan
+++ b/transforms/log_simplex/AugmentedSoftmax.stan
@@ -1,0 +1,23 @@
+functions{
+  vector augmented_softmax_log_simplex_constrain_lp(vector y) {
+    int N = nrows(y);
+    real log_r = log_sum_exp(y);
+    vector[N] log_x = y - log_r;
+    target += -log_r;
+    target += std_normal_lupdf(log_r - log(N));
+    return log_x;
+  }
+}
+data {
+  int<lower=0> N;
+  vector<lower=0>[N] alpha;
+}
+parameters {
+  vector[N] y;
+}
+transformed parameters {
+  vector<upper=0>[N] log_x = augmented_softmax_log_simplex_constrain_lp(y);
+}
+model {
+  target += target_density_lp(x, alpha);
+}

--- a/transforms/log_simplex/NormalizedExponential.stan
+++ b/transforms/log_simplex/NormalizedExponential.stan
@@ -10,7 +10,7 @@ functions {
     real log_r = negative_infinity();
     for (i in 1:N) {
       log_u = std_normal_lcdf(y[i]);
-      z[i] = exponential_log_qf(log_u);
+      z[i] = log(exponential_log_qf(log_u));
     }
     log_r = log_sum_exp(z);
     log_x = z - log_r;

--- a/transforms/log_simplex/NormalizedExponential.stan
+++ b/transforms/log_simplex/NormalizedExponential.stan
@@ -29,6 +29,7 @@ parameters {
 }
 transformed parameters {
   vector<upper=0>[N] log_x = normalized_exponential_log_simplex_constrain_lp(y);
+  simplex[N] x = exp(log_x);
 }
 model {
   target += target_density_lp(log_x, alpha);

--- a/transforms/log_simplex/NormalizedExponential.stan
+++ b/transforms/log_simplex/NormalizedExponential.stan
@@ -1,0 +1,35 @@
+functions {
+  real exponential_log_qf(real logp){
+    return -log1m_exp(logp);
+  }
+  vector normalized_exponential_log_simplex_constrain_lp(vector y) {
+    int N = rows(y);
+    vector[N] log_x;
+    vector[N] z;
+    real log_u;
+    real log_r = negative_infinity();
+    for (i in 1:N) {
+      log_u = std_normal_lcdf(y[i]);
+      z[i] = exponential_log_qf(log_u);
+    }
+    log_r = log_sum_exp(z);
+    log_x = z - log_r;
+    for (i in 1:(N - 1))
+      target += -log_x[i];
+    target += std_normal_lpdf(y);
+    return log_x;
+  }
+}
+data {
+  int<lower=0> N;
+  vector<lower=0>[N] alpha;
+}
+parameters {
+  vector[N] y;
+}
+transformed parameters {
+  vector<upper=0>[N] log_x = normalized_exponential_log_simplex_constrain_lp(y);
+}
+model {
+  target += target_density_lp(log_x, alpha);
+}

--- a/transforms/log_simplex/NormalizedExponential.stan
+++ b/transforms/log_simplex/NormalizedExponential.stan
@@ -13,8 +13,7 @@ functions {
     }
     real log_r = log_sum_exp(z);
     log_x = z - log_r;
-    for (i in 1:(N - 1))
-      target += -log_x[i];
+    target += -log_x[1:N - 1];
     target += std_normal_lpdf(y);
     return log_x;
   }

--- a/transforms/log_simplex/NormalizedExponential.stan
+++ b/transforms/log_simplex/NormalizedExponential.stan
@@ -7,12 +7,11 @@ functions {
     vector[N] log_x;
     vector[N] z;
     real log_u;
-    real log_r = negative_infinity();
     for (i in 1:N) {
       log_u = std_normal_lcdf(y[i]);
       z[i] = log(exponential_log_qf(log_u));
     }
-    log_r = log_sum_exp(z);
+    real log_r = log_sum_exp(z);
     log_x = z - log_r;
     for (i in 1:(N - 1))
       target += -log_x[i];

--- a/transforms/log_simplex/NormalizedExponential.stan
+++ b/transforms/log_simplex/NormalizedExponential.stan
@@ -4,7 +4,6 @@ functions {
   }
   vector normalized_exponential_log_simplex_constrain_lp(vector y) {
     int N = rows(y);
-    vector[N] log_x;
     vector[N] z;
     real log_u;
     for (i in 1:N) {
@@ -12,7 +11,7 @@ functions {
       z[i] = log(exponential_log_qf(log_u));
     }
     real log_r = log_sum_exp(z);
-    log_x = z - log_r;
+    vector[N] log_x = z - log_r;
     target += -log_x[1:N - 1];
     target += std_normal_lpdf(y);
     return log_x;

--- a/transforms/log_simplex/StanStickbreaking.stan
+++ b/transforms/log_simplex/StanStickbreaking.stan
@@ -9,7 +9,6 @@ transformed parameters {
   vector<upper=0>[N] log_x = log(x);
 }
 model {
-  for i in 1:(N - 1)
-    target += -log_x[i];
+  target += -log_x[1:N - 1];
   target += target_density_lp(log_x, alpha);
 }

--- a/transforms/log_simplex/StanStickbreaking.stan
+++ b/transforms/log_simplex/StanStickbreaking.stan
@@ -1,0 +1,15 @@
+data {
+  int<lower=0> N;
+  vector<lower=0>[N] alpha;
+}
+parameters {
+  simplex[N] x;
+}
+transformed parameters {
+  vector<upper=0>[N] log_x = log(x);
+}
+model {
+  for i in 1:(N - 1)
+    target += -log_x[i];
+  target += target_density_lp(log_x, alpha);
+}

--- a/transforms/log_simplex/Stickbreaking.stan
+++ b/transforms/log_simplex/Stickbreaking.stan
@@ -1,17 +1,17 @@
 functions {
   vector stickbreaking_log_simplex_constrain_lp(vector y) {
     int N = rows(y) + 1;
-    vector[N-1] log_z = log_inv_logit(y - log(reverse(linspaced_vector(N - 1, 1, N - 1))));
     vector[N] log_x;
-    log_x[1] = log_z[1];
-    real log_cum_sum = negative_infinity();
-    for (i in 2:N - 1) {
-      log_cum_sum = log_sum_exp(log_cum_sum, log_x[i - 1]);
-      log_x[i] = log1m_exp(log_cum_sum) + log_z[i];
+    real log_z;
+    real log_cum_prod = 0;
+    for (i in 1:(N - 1)) {
+      log_z = log_inv_logit(y[i] - log(N - i));
+      log_x[i] = log_cum_prod + log_z;
+      log_cum_prod += log1m_exp(log_z);
     }   
-    log_x[N] = log1m_exp(log_sum_exp(log_cum_sum, log_x[N-1]));
-    target += log_x[N];
-    return log_x;    
+    log_x[N] = log_cum_prod;
+    target += log_cum_prod;
+    return log_x;
   }
 }
 data {

--- a/transforms/log_simplex/Stickbreaking.stan
+++ b/transforms/log_simplex/Stickbreaking.stan
@@ -1,0 +1,30 @@
+functions {
+  vector stickbreaking_log_simplex_constrain_lp(vector y) {
+    int N = rows(y) + 1;
+    vector[N-1] log_z = log_inv_logit(y - log(reverse(linspaced_vector(N - 1, 1, N - 1))));
+    vector[N] log_x;
+    log_x[1] = log_z[1];
+    real log_cum_sum = negative_infinity();
+    for (n in 2:N - 1) {
+      log_cum_sum = log_sum_exp(log_cum_sum, log_x[n - 1]);
+      log_x[n] = log1m_exp(log_cum_sum) + log_z[n];
+    }   
+    log_x[N] = log1m_exp(log_sum_exp(log_cum_sum, log_x[N-1]));
+    target += log_x[N];
+    return log_x;    
+  }
+}
+data {
+  int<lower=0> N;
+  vector<lower=0>[N] alpha;
+}
+parameters {
+  vector[N - 1] y;
+}
+transformed parameters {
+  vector<upper=0>[N] log_x = stickbreaking_log_simplex_constrain_lp(y);
+  simplex[N] x = exp(log_x);
+}
+model {
+  target += target_density_lp(log_x, alpha);
+}

--- a/transforms/log_simplex/Stickbreaking.stan
+++ b/transforms/log_simplex/Stickbreaking.stan
@@ -5,9 +5,9 @@ functions {
     vector[N] log_x;
     log_x[1] = log_z[1];
     real log_cum_sum = negative_infinity();
-    for (n in 2:N - 1) {
-      log_cum_sum = log_sum_exp(log_cum_sum, log_x[n - 1]);
-      log_x[n] = log1m_exp(log_cum_sum) + log_z[n];
+    for (i in 2:N - 1) {
+      log_cum_sum = log_sum_exp(log_cum_sum, log_x[i - 1]);
+      log_x[i] = log1m_exp(log_cum_sum) + log_z[i];
     }   
     log_x[N] = log1m_exp(log_sum_exp(log_cum_sum, log_x[N-1]));
     target += log_x[N];

--- a/transforms/log_simplex/StickbreakingAngular.stan
+++ b/transforms/log_simplex/StickbreakingAngular.stan
@@ -1,0 +1,39 @@
+functions {
+  vector stickbricking_angular_log_simplex_constrain_lp(vector y) {
+    int N = rows(y) + 1;
+    vector[N] log_x;
+    real log_phi, phi, log_u, log_s, log_c;
+    real log_s2_prod = 0;
+    real log_halfpi = log(pi()) - log2();
+    int rcounter = 2 * N - 3;
+    for (i in 1:(N-1)) {
+      log_u = log_inv_logit(y[i]);
+      log_phi = log_u + log_halfpi;
+      phi = exp(log_phi);
+      log_s = log(sin(phi));
+      log_c = log(cos(phi));
+      log_x[i] = log_s2_prod + 2 * log_c;
+      log_s2_prod += 2 * log_s;
+      target += log_phi + log1m_exp(log_u) + rcounter * log_s + log_c;
+      target += -log_x[i];
+      rcounter -= 2;
+    }
+    log_x[N] = log_s2_prod;
+    target += (N - 1) * log2();
+    return log_x;
+  }
+}
+data {
+  int<lower=0> N;
+  vector<lower=0>[N] alpha;
+}
+parameters {
+  vector[N - 1] y;
+}
+transformed parameters {
+  vector<upper=0>[N] log_x = stickbricking_angular_log_simplex_constrain_lp(y);
+  simplex[N] x = exp(log_x);
+}
+model {
+  target += target_density_lp(log_x, alpha);
+}

--- a/transforms/log_simplex/StickbreakingLogistic.stan
+++ b/transforms/log_simplex/StickbreakingLogistic.stan
@@ -1,11 +1,11 @@
 functions {
-  vector stickbreaking_log_simplex_constrain_lp(vector y) {
+  vector stickbreaking_logistic_log_simplex_constrain_lp(vector y) {
     int N = rows(y) + 1;
     vector[N] log_x;
     real log_z;
     real log_cum_prod = 0;
     for (i in 1:(N - 1)) {
-      log_z = log_inv_logit(y[i] - log(N - i));
+      log_z = log_inv_logit(y[i] - log(N - i)); // logistic_lcdf(y[i] | log(N - i), 1)
       log_x[i] = log_cum_prod + log_z;
       log_cum_prod += log1m_exp(log_z);
     }   
@@ -22,7 +22,7 @@ parameters {
   vector[N - 1] y;
 }
 transformed parameters {
-  vector<upper=0>[N] log_x = stickbreaking_log_simplex_constrain_lp(y);
+  vector<upper=0>[N] log_x = stickbreaking_logistic_log_simplex_constrain_lp(y);
   simplex[N] x = exp(log_x);
 }
 model {

--- a/transforms/log_simplex/StickbreakingNormal.stan
+++ b/transforms/log_simplex/StickbreakingNormal.stan
@@ -1,0 +1,31 @@
+functions {
+  vector stickbreaking_normal_log_simplex_constrain_lp(vector y) {
+    int N = rows(y) + 1;
+    vector[N] log_x;
+    real log_zi, wi;
+    real log_cum_prod = 0;
+    for (i in 1:N - 1) {
+      wi = y[i] - log(N - i) / 2;
+      log_zi = std_normal_lcdf(wi);
+      log_x[i] = log_cum_prod + log_zi;
+      target += std_normal_lpdf(wi) - log_zi;
+      log_cum_prod += log1m_exp(log_zi);
+    }
+    log_x[N] = log_cum_prod;
+    return log_x;
+  }
+}
+data {
+  int<lower=0> N;
+  vector<lower=0>[N] alpha;
+}
+parameters {
+  vector[N - 1] y;
+}
+transformed parameters {
+  vector<upper=0>[N] log_x = stickbreaking_normal_log_simplex_constrain_lp(y);
+  simplex[N] x = exp(log_x);
+}
+model {
+  target += target_density_lp(log_x, alpha);
+}

--- a/transforms/log_simplex/StickbreakingPowerLogistic.stan
+++ b/transforms/log_simplex/StickbreakingPowerLogistic.stan
@@ -1,0 +1,34 @@
+functions {
+  vector stickbreaking_power_logistic_log_simplex_constrain_lp(vector y) {
+    int N = rows(y) + 1;
+    vector[N] log_x;
+    real log_u, log_w, log_z;
+    real log_cum_prod = 0;
+    for (i in 1:(N-1)) {
+      log_u = log_inv_logit(y[i]); // logistic_lcdf(y[i] | 0, 1);
+      log_w = log_u / (N - i);
+      log_z = log1m_exp(log_w);
+      log_x[i] = log_cum_prod + log_z;
+      target += 2 * log_u - y[i]; // logistic_lupdf(y[i] | 0, 1);
+      target += -log_x[i];
+      log_cum_prod += log1m_exp(log_z);
+    }
+    log_x[N] = log_cum_prod;
+    target += -lgamma(N);
+    return log_x;
+  }
+}
+data {
+  int<lower=0> N;
+  vector<lower=0>[N] alpha;
+}
+parameters {
+  vector[N - 1] y;
+}
+transformed parameters {
+  vector<upper=0>[N] log_x = stickbreaking_power_logistic_log_simplex_constrain_lp(y);
+  simplex[N] x = exp(log_x);
+}
+model {
+  target += target_density_lp(log_x, alpha);
+}

--- a/transforms/log_simplex/StickbreakingPowerNormal.stan
+++ b/transforms/log_simplex/StickbreakingPowerNormal.stan
@@ -1,0 +1,34 @@
+functions {
+  vector stickbreaking_power_normal_log_simplex_constrain_lp(vector y) {
+    int N = rows(y) + 1;
+    vector[N] log_x;
+    real log_u, log_w, log_z;
+    real log_cum_prod = 0;
+    for (i in 1:(N-1)) {
+      log_u = std_normal_lcdf(y[i] |);
+      log_w = log_u / (N - i);
+      log_z = log1m_exp(log_w);
+      log_x[i] = log_cum_prod + log_z;
+      target += std_normal_lpdf(y[i] |);
+      target += -log_x[i];
+      log_cum_prod += log1m_exp(log_z);
+    }
+    log_x[N] = log_cum_prod;
+    target += -lgamma(N);
+    return log_x;
+  }
+}
+data {
+  int<lower=0> N;
+  vector<lower=0>[N] alpha;
+}
+parameters {
+  vector[N - 1] y;
+}
+transformed parameters {
+  vector<upper=0>[N] log_x = stickbreaking_power_normal_log_simplex_constrain_lp(y);
+  simplex[N] x = exp(log_x);
+}
+model {
+  target += target_density_lp(log_x, alpha);
+}


### PR DESCRIPTION
Following #65, this PR adds versions of our transforms for the log-simplex. It also adds a log-Dirichlet target.

Note that `LogDirichlet(log_x | alpha) = Dirichlet(exp(log_x) | α) * exp(sum(log_x[1:(N-1)]))`, while the Jacobian corrections in the transforms are adjusted by `exp(-sum(log_x[1:(N-1)]))`, i.e. in the opposite direction.